### PR TITLE
Add PiccManager support

### DIFF
--- a/android/src/main/kotlin/com/example/flutter_urovo_scan/FlutterUrovoScanPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_urovo_scan/FlutterUrovoScanPlugin.kt
@@ -25,12 +25,14 @@ class FlutterUrovoScanPlugin: FlutterPlugin, MethodCallHandler {
   private var eventSink: EventChannel.EventSink? = null
   private lateinit var helperUtil: HelperUtil
   private lateinit var scannerHelper: ScannerManagerHelper
+  private lateinit var piccHelper: PiccManagerHelper
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     Log.d("[TEST]", "FlutterUrovoScanPlugin: onAttachedToEngine")
     context = flutterPluginBinding.applicationContext
     scannerHelper = ScannerManagerHelper(context, this)
     helperUtil = HelperUtil(context)
+    piccHelper = PiccManagerHelper()
 
     // Set Method Channel
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_urovo_scan")
@@ -78,6 +80,26 @@ class FlutterUrovoScanPlugin: FlutterPlugin, MethodCallHandler {
       "getParameterInts" -> scannerHelper.getParameterInts(result)
       "startDecode" -> scannerHelper.startDecode(result)
       "stopDecode" -> scannerHelper.stopDecode(result)
+      "piccOpen" -> piccHelper.open(result)
+      "piccClose" -> piccHelper.close(result)
+      "piccRequest" -> {
+        val mode: String = call.argument<String>("mode") ?: "A"
+        piccHelper.request(mode, result)
+      }
+      "piccAntisel" -> piccHelper.antisel(result)
+      "piccActivate" -> piccHelper.activate(result)
+      "piccDeactivate" -> {
+        val mode: Int = call.argument<Int>("mode") ?: 0
+        piccHelper.deactivate(mode, result)
+      }
+      "piccApduTransmit" -> {
+        val cmd: ByteArray? = call.argument<ByteArray>("cmd")
+        if (cmd != null) {
+          piccHelper.apduTransmit(cmd, result)
+        } else {
+          result.error("ERROR", "cmd is null", null)
+        }
+      }
       else -> result.notImplemented()
     }
   }

--- a/android/src/main/kotlin/com/example/flutter_urovo_scan/PiccManagerHelper.kt
+++ b/android/src/main/kotlin/com/example/flutter_urovo_scan/PiccManagerHelper.kt
@@ -1,0 +1,117 @@
+package com.example.flutter_urovo_scan
+
+import android.device.PiccManager
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Helper class to interact with [PiccManager].
+ * Provides wrapper methods that return results via a [MethodChannel.Result].
+ */
+class PiccManagerHelper {
+    private val piccManager: PiccManager = PiccManager()
+
+    fun open(result: MethodChannel.Result) {
+        try {
+            val ret = piccManager.open()
+            if (ret == 0) {
+                result.success("SUCCESS")
+            } else {
+                result.error("ERROR", "open failed: $ret", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "open exception: ${e.message}", null)
+        }
+    }
+
+    fun close(result: MethodChannel.Result) {
+        try {
+            val ret = piccManager.close()
+            if (ret == 0) {
+                result.success("SUCCESS")
+            } else {
+                result.error("ERROR", "close failed: $ret", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "close exception: ${e.message}", null)
+        }
+    }
+
+    fun request(mode: String, result: MethodChannel.Result) {
+        try {
+            val atq = ByteArray(16)
+            val modeByte = byteArrayOf(mode.first().code.toByte())
+            val len = piccManager.request(modeByte, atq)
+            if (len >= 0) {
+                result.success(toHex(atq.copyOf(len)))
+            } else {
+                result.error("ERROR", "request failed: $len", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "request exception: ${e.message}", null)
+        }
+    }
+
+    fun antisel(result: MethodChannel.Result) {
+        try {
+            val sn = ByteArray(16)
+            val sak = ByteArray(16)
+            val len = piccManager.antisel(sn, sak)
+            if (len >= 0) {
+                result.success(toHex(sn.copyOf(len)))
+            } else {
+                result.error("ERROR", "antisel failed: $len", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "antisel exception: ${e.message}", null)
+        }
+    }
+
+    fun activate(result: MethodChannel.Result) {
+        try {
+            val ret = piccManager.activate()
+            if (ret == 0) {
+                result.success("SUCCESS")
+            } else {
+                result.error("ERROR", "activate failed: $ret", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "activate exception: ${e.message}", null)
+        }
+    }
+
+    fun deactivate(mode: Int, result: MethodChannel.Result) {
+        try {
+            val ret = piccManager.deactivate(mode.toByte())
+            if (ret == 0) {
+                result.success("SUCCESS")
+            } else {
+                result.error("ERROR", "deactivate failed: $ret", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "deactivate exception: ${e.message}", null)
+        }
+    }
+
+    fun apduTransmit(cmd: ByteArray, result: MethodChannel.Result) {
+        try {
+            val rsp = ByteArray(256)
+            val sw = ByteArray(2)
+            val len = piccManager.apduTransmit(cmd, cmd.size, rsp, sw)
+            if (len >= 0) {
+                val map = HashMap<String, Any>()
+                map["rsp"] = rsp.copyOf(len).toList()
+                map["sw"] = sw.toList()
+                result.success(map)
+            } else {
+                result.error("ERROR", "apduTransmit failed: $len", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "apduTransmit exception: ${e.message}", null)
+        }
+    }
+
+    private fun toHex(data: ByteArray): String {
+        return data.joinToString("") { String.format("%02X", it) }
+    }
+}
+

--- a/lib/flutter_urovo_scan.dart
+++ b/lib/flutter_urovo_scan.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -109,6 +110,34 @@ class FlutterUrovoScan {
   /// This function stops the scanning process.
   Future<String?> stopDecode() {
     return FlutterUrovoScanPlatform.instance.stopDecode();
+  }
+
+  Future<String?> piccOpen() {
+    return FlutterUrovoScanPlatform.instance.piccOpen();
+  }
+
+  Future<String?> piccClose() {
+    return FlutterUrovoScanPlatform.instance.piccClose();
+  }
+
+  Future<String?> piccRequest(String mode) {
+    return FlutterUrovoScanPlatform.instance.piccRequest(mode);
+  }
+
+  Future<String?> piccAntisel() {
+    return FlutterUrovoScanPlatform.instance.piccAntisel();
+  }
+
+  Future<String?> piccActivate() {
+    return FlutterUrovoScanPlatform.instance.piccActivate();
+  }
+
+  Future<String?> piccDeactivate(int mode) {
+    return FlutterUrovoScanPlatform.instance.piccDeactivate(mode);
+  }
+
+  Future<Map<String, dynamic>?> piccApduTransmit(Uint8List cmd) {
+    return FlutterUrovoScanPlatform.instance.piccApduTransmit(cmd);
   }
 }
 

--- a/lib/flutter_urovo_scan_method_channel.dart
+++ b/lib/flutter_urovo_scan_method_channel.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -171,6 +172,97 @@ class MethodChannelFlutterUrovoScan extends FlutterUrovoScanPlatform {
 
     try {
       final result = await methodChannel.invokeMethod<String>('stopDecode');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> piccOpen() async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('piccOpen');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> piccClose() async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('piccClose');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> piccRequest(String mode) async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('piccRequest', {'mode': mode});
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> piccAntisel() async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('piccAntisel');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> piccActivate() async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('piccActivate');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> piccDeactivate(int mode) async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('piccDeactivate', {'mode': mode});
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>?> piccApduTransmit(Uint8List cmd) async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMapMethod<String, dynamic>('piccApduTransmit', {'cmd': cmd});
       return result;
     } catch (e) {
       throw Exception('[MethodChannelError] ${e.toString()}');

--- a/lib/flutter_urovo_scan_platform_interface.dart
+++ b/lib/flutter_urovo_scan_platform_interface.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'flutter_urovo_scan_method_channel.dart';
@@ -69,5 +70,33 @@ abstract class FlutterUrovoScanPlatform extends PlatformInterface {
 
   Future<String?> stopDecode() {
     throw UnimplementedError('stopDecode() has not been implemented.');
+  }
+
+  Future<String?> piccOpen() {
+    throw UnimplementedError('piccOpen() has not been implemented.');
+  }
+
+  Future<String?> piccClose() {
+    throw UnimplementedError('piccClose() has not been implemented.');
+  }
+
+  Future<String?> piccRequest(String mode) {
+    throw UnimplementedError('piccRequest() has not been implemented.');
+  }
+
+  Future<String?> piccAntisel() {
+    throw UnimplementedError('piccAntisel() has not been implemented.');
+  }
+
+  Future<String?> piccActivate() {
+    throw UnimplementedError('piccActivate() has not been implemented.');
+  }
+
+  Future<String?> piccDeactivate(int mode) {
+    throw UnimplementedError('piccDeactivate() has not been implemented.');
+  }
+
+  Future<Map<String, dynamic>?> piccApduTransmit(Uint8List cmd) {
+    throw UnimplementedError('piccApduTransmit() has not been implemented.');
   }
 }

--- a/test/flutter_urovo_scan_method_channel_test.dart
+++ b/test/flutter_urovo_scan_method_channel_test.dart
@@ -24,4 +24,8 @@ void main() {
   test('getPlatformVersion', () async {
     expect(await platform.getPlatformVersion(), '42');
   });
+
+  test('piccOpen', () async {
+    expect(await platform.piccOpen(), '42');
+  });
 }

--- a/test/flutter_urovo_scan_test.dart
+++ b/test/flutter_urovo_scan_test.dart
@@ -1,3 +1,4 @@
+import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_urovo_scan/flutter_urovo_scan.dart';
 import 'package:flutter_urovo_scan/flutter_urovo_scan_platform_interface.dart';
@@ -42,6 +43,27 @@ class MockFlutterUrovoScanPlatform
 
   @override
   Future<String?> stopDecode() => Future.value('Success');
+
+  @override
+  Future<String?> piccOpen() => Future.value('Success');
+
+  @override
+  Future<String?> piccClose() => Future.value('Success');
+
+  @override
+  Future<String?> piccRequest(String mode) => Future.value('ATQ');
+
+  @override
+  Future<String?> piccAntisel() => Future.value('SN');
+
+  @override
+  Future<String?> piccActivate() => Future.value('Success');
+
+  @override
+  Future<String?> piccDeactivate(int mode) => Future.value('Success');
+
+  @override
+  Future<Map<String, dynamic>?> piccApduTransmit(Uint8List cmd) => Future.value({'rsp': [0], 'sw': [0,0]});
 }
 
 void main() {
@@ -136,5 +158,13 @@ void main() {
     FlutterUrovoScanPlatform.instance = fakePlatform;
 
     expect(await flutterUrovoScanPlugin.stopDecode(), 'Success');
+  });
+
+  test('piccOpen', () async {
+    FlutterUrovoScan flutterUrovoScanPlugin = FlutterUrovoScan();
+    MockFlutterUrovoScanPlatform fakePlatform = MockFlutterUrovoScanPlatform();
+    FlutterUrovoScanPlatform.instance = fakePlatform;
+
+    expect(await flutterUrovoScanPlugin.piccOpen(), 'Success');
   });
 }


### PR DESCRIPTION
## Summary
- add PiccManager helper and platform methods for card operations
- expose PiccManager APIs through Flutter interface and method channel
- expand tests for new PiccManager methods

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `dart format lib test android/src/main/kotlin/com/example/flutter_urovo_scan/*.kt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68946bc9d2a8832f84c4144f8bff7f93