### PR TITLE
feat: add ICC card manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ A Flutter plugin for integrating **Urovo barcode scanners** with Android devices
 - 🔹 **Real-time barcode scanning** using Urovo SDK
 - 🔹 **Event-based scan results** via Flutter’s `EventChannel`
 - 🔹 **Easy integration** with Flutter apps
+- 🔹 **Access to PICC and ICC card readers** for smart card interactions

--- a/android/src/main/kotlin/com/example/flutter_urovo_scan/FlutterUrovoScanPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_urovo_scan/FlutterUrovoScanPlugin.kt
@@ -26,6 +26,7 @@ class FlutterUrovoScanPlugin: FlutterPlugin, MethodCallHandler {
   private lateinit var helperUtil: HelperUtil
   private lateinit var scannerHelper: ScannerManagerHelper
   private lateinit var piccHelper: PiccManagerHelper
+  private lateinit var iccHelper: IccManagerHelper
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     Log.d("[TEST]", "FlutterUrovoScanPlugin: onAttachedToEngine")
@@ -33,6 +34,7 @@ class FlutterUrovoScanPlugin: FlutterPlugin, MethodCallHandler {
     scannerHelper = ScannerManagerHelper(context, this)
     helperUtil = HelperUtil(context)
     piccHelper = PiccManagerHelper()
+    iccHelper = IccManagerHelper()
 
     // Set Method Channel
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_urovo_scan")
@@ -100,6 +102,24 @@ class FlutterUrovoScanPlugin: FlutterPlugin, MethodCallHandler {
           result.error("ERROR", "cmd is null", null)
         }
       }
+      "iccOpen" -> {
+        val slot: Int = call.argument<Int>("slot") ?: 0
+        val cardType: Int = call.argument<Int>("cardType") ?: 1
+        val volt: Int = call.argument<Int>("volt") ?: 1
+        iccHelper.open(slot, cardType, volt, result)
+      }
+      "iccClose" -> iccHelper.close(result)
+      "iccDetect" -> iccHelper.detect(result)
+      "iccActivate" -> iccHelper.activate(result)
+      "iccApduTransmit" -> {
+        val cmd: ByteArray? = call.argument<ByteArray>("cmd")
+        if (cmd != null) {
+          iccHelper.apduTransmit(cmd, result)
+        } else {
+          result.error("ERROR", "cmd is null", null)
+        }
+      }
+      "iccDeactivate" -> iccHelper.deactivate(result)
       else -> result.notImplemented()
     }
   }

--- a/android/src/main/kotlin/com/example/flutter_urovo_scan/IccManagerHelper.kt
+++ b/android/src/main/kotlin/com/example/flutter_urovo_scan/IccManagerHelper.kt
@@ -1,0 +1,101 @@
+package com.example.flutter_urovo_scan
+
+import android.device.IccManager
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Helper class to interact with [IccManager].
+ * Provides wrapper methods that return results via a [MethodChannel.Result].
+ */
+class IccManagerHelper {
+    private val iccManager: IccManager = IccManager()
+
+    fun open(slot: Int, cardType: Int, volt: Int, result: MethodChannel.Result) {
+        try {
+            val ret = iccManager.open(slot.toByte(), cardType.toByte(), volt.toByte())
+            if (ret == 0) {
+                result.success("SUCCESS")
+            } else {
+                result.error("ERROR", "open failed: $ret", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "open exception: ${e.message}", null)
+        }
+    }
+
+    fun close(result: MethodChannel.Result) {
+        try {
+            val ret = iccManager.close()
+            if (ret == 0) {
+                result.success("SUCCESS")
+            } else {
+                result.error("ERROR", "close failed: $ret", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "close exception: ${e.message}", null)
+        }
+    }
+
+    fun detect(result: MethodChannel.Result) {
+        try {
+            val ret = iccManager.detect()
+            if (ret == 0) {
+                result.success("SUCCESS")
+            } else {
+                result.error("ERROR", "detect failed: $ret", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "detect exception: ${e.message}", null)
+        }
+    }
+
+    fun activate(result: MethodChannel.Result) {
+        try {
+            val atr = ByteArray(64)
+            val len = iccManager.activate(atr)
+            if (len >= 0) {
+                result.success(toHex(atr.copyOf(len)))
+            } else {
+                result.error("ERROR", "activate failed: $len", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "activate exception: ${e.message}", null)
+        }
+    }
+
+    fun apduTransmit(cmd: ByteArray, result: MethodChannel.Result) {
+        try {
+            val rsp = ByteArray(256)
+            val sw = ByteArray(2)
+            val len = iccManager.apduTransmit(cmd, cmd.size, rsp, sw)
+            if (len >= 0) {
+                val map = HashMap<String, Any>()
+                map["rsp"] = rsp.copyOf(len).toList()
+                map["sw"] = sw.toList()
+                result.success(map)
+            } else {
+                result.error("ERROR", "apduTransmit failed: $len", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "apduTransmit exception: ${e.message}", null)
+        }
+    }
+
+    fun deactivate(result: MethodChannel.Result) {
+        try {
+            val ret = iccManager.deactivate()
+            if (ret == 0) {
+                result.success("SUCCESS")
+            } else {
+                result.error("ERROR", "deactivate failed: $ret", null)
+            }
+        } catch (e: Exception) {
+            result.error("ERROR", "deactivate exception: ${e.message}", null)
+        }
+    }
+
+    private fun toHex(data: ByteArray): String {
+        return data.joinToString("") { String.format("%02X", it) }
+    }
+}
+

--- a/lib/flutter_urovo_scan.dart
+++ b/lib/flutter_urovo_scan.dart
@@ -139,6 +139,30 @@ class FlutterUrovoScan {
   Future<Map<String, dynamic>?> piccApduTransmit(Uint8List cmd) {
     return FlutterUrovoScanPlatform.instance.piccApduTransmit(cmd);
   }
+
+  Future<String?> iccOpen(int slot, int cardType, int volt) {
+    return FlutterUrovoScanPlatform.instance.iccOpen(slot, cardType, volt);
+  }
+
+  Future<String?> iccClose() {
+    return FlutterUrovoScanPlatform.instance.iccClose();
+  }
+
+  Future<String?> iccDetect() {
+    return FlutterUrovoScanPlatform.instance.iccDetect();
+  }
+
+  Future<String?> iccActivate() {
+    return FlutterUrovoScanPlatform.instance.iccActivate();
+  }
+
+  Future<Map<String, dynamic>?> iccApduTransmit(Uint8List cmd) {
+    return FlutterUrovoScanPlatform.instance.iccApduTransmit(cmd);
+  }
+
+  Future<String?> iccDeactivate() {
+    return FlutterUrovoScanPlatform.instance.iccDeactivate();
+  }
 }
 
 class ScannerListener {

--- a/lib/flutter_urovo_scan_method_channel.dart
+++ b/lib/flutter_urovo_scan_method_channel.dart
@@ -268,4 +268,87 @@ class MethodChannelFlutterUrovoScan extends FlutterUrovoScanPlatform {
       throw Exception('[MethodChannelError] ${e.toString()}');
     }
   }
+
+  @override
+  Future<String?> iccOpen(int slot, int cardType, int volt) async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('iccOpen', {
+        'slot': slot,
+        'cardType': cardType,
+        'volt': volt,
+      });
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> iccClose() async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('iccClose');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> iccDetect() async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('iccDetect');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> iccActivate() async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('iccActivate');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>?> iccApduTransmit(Uint8List cmd) async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMapMethod<String, dynamic>(
+          'iccApduTransmit', {'cmd': cmd});
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
+
+  @override
+  Future<String?> iccDeactivate() async {
+    if (!Platform.isAndroid) {
+      throw Exception('Available only for Android');
+    }
+    try {
+      final result = await methodChannel.invokeMethod<String>('iccDeactivate');
+      return result;
+    } catch (e) {
+      throw Exception('[MethodChannelError] ${e.toString()}');
+    }
+  }
 }

--- a/lib/flutter_urovo_scan_platform_interface.dart
+++ b/lib/flutter_urovo_scan_platform_interface.dart
@@ -99,4 +99,28 @@ abstract class FlutterUrovoScanPlatform extends PlatformInterface {
   Future<Map<String, dynamic>?> piccApduTransmit(Uint8List cmd) {
     throw UnimplementedError('piccApduTransmit() has not been implemented.');
   }
+
+  Future<String?> iccOpen(int slot, int cardType, int volt) {
+    throw UnimplementedError('iccOpen() has not been implemented.');
+  }
+
+  Future<String?> iccClose() {
+    throw UnimplementedError('iccClose() has not been implemented.');
+  }
+
+  Future<String?> iccDetect() {
+    throw UnimplementedError('iccDetect() has not been implemented.');
+  }
+
+  Future<String?> iccActivate() {
+    throw UnimplementedError('iccActivate() has not been implemented.');
+  }
+
+  Future<Map<String, dynamic>?> iccApduTransmit(Uint8List cmd) {
+    throw UnimplementedError('iccApduTransmit() has not been implemented.');
+  }
+
+  Future<String?> iccDeactivate() {
+    throw UnimplementedError('iccDeactivate() has not been implemented.');
+  }
 }

--- a/test/flutter_urovo_scan_method_channel_test.dart
+++ b/test/flutter_urovo_scan_method_channel_test.dart
@@ -28,4 +28,8 @@ void main() {
   test('piccOpen', () async {
     expect(await platform.piccOpen(), '42');
   });
+
+  test('iccOpen', () async {
+    expect(await platform.iccOpen(0,1,1), '42');
+  });
 }

--- a/test/flutter_urovo_scan_test.dart
+++ b/test/flutter_urovo_scan_test.dart
@@ -64,6 +64,24 @@ class MockFlutterUrovoScanPlatform
 
   @override
   Future<Map<String, dynamic>?> piccApduTransmit(Uint8List cmd) => Future.value({'rsp': [0], 'sw': [0,0]});
+
+  @override
+  Future<String?> iccOpen(int slot, int cardType, int volt) => Future.value('Success');
+
+  @override
+  Future<String?> iccClose() => Future.value('Success');
+
+  @override
+  Future<String?> iccDetect() => Future.value('Success');
+
+  @override
+  Future<String?> iccActivate() => Future.value('ATR');
+
+  @override
+  Future<Map<String, dynamic>?> iccApduTransmit(Uint8List cmd) => Future.value({'rsp': [0], 'sw': [0,0]});
+
+  @override
+  Future<String?> iccDeactivate() => Future.value('Success');
 }
 
 void main() {
@@ -166,5 +184,13 @@ void main() {
     FlutterUrovoScanPlatform.instance = fakePlatform;
 
     expect(await flutterUrovoScanPlugin.piccOpen(), 'Success');
+  });
+
+  test('iccOpen', () async {
+    FlutterUrovoScan flutterUrovoScanPlugin = FlutterUrovoScan();
+    MockFlutterUrovoScanPlatform fakePlatform = MockFlutterUrovoScanPlatform();
+    FlutterUrovoScanPlatform.instance = fakePlatform;
+
+    expect(await flutterUrovoScanPlugin.iccOpen(0,1,1), 'Success');
   });
 }


### PR DESCRIPTION
## Summary
- add Kotlin helper around `IccManager` for ICC card operations
- expose ICC open/close/detect/activate/APDU/deactivate through MethodChannel and Dart API
- document PICC and ICC support in README

## Testing
- `flutter test` *(fails: command not found)*
- `sudo apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68947222812c832f8ab9c70e32a1e27c